### PR TITLE
Stored characters on Saved page

### DIFF
--- a/src/pages/SavedCharactersPage/SavedCharactersPage.tsx
+++ b/src/pages/SavedCharactersPage/SavedCharactersPage.tsx
@@ -4,11 +4,25 @@ import HelpButton from "../../components/HelpButton";
 
 import testCharacter from "../../constants/character.json";
 import { Character } from "../../interfaces";
+import { GetAllCharacters } from "../../utils/db";
+
+import { useState } from "react"
 
 /**
  * Page that lists all saved characters from the user's browser.
  */
 export function SavedCharactersPage() {
+
+  const [savedCharacters, setSavedCharacters] = useState<Character[]>();
+  const [run, setRun] = useState(0);
+
+  async function GetSavedCharacters() {
+    setRun(1);
+    setSavedCharacters(await GetAllCharacters());
+  }
+
+  if (run == 0) GetSavedCharacters();
+
   return (
     <section id="saved-characters-page" className="section page">
       <HelpButton heading="Saved Characters Page" className="is-pulled-right">
@@ -23,7 +37,12 @@ export function SavedCharactersPage() {
         <h1 className="title">Saved Characters</h1>
 
         <div className="columns is-multiline">
-          <div className="column is-3">
+          {savedCharacters?.map((character) => (
+            <div className = "column is-3">
+              <CharacterPreview character = { character as Character } />
+            </div>
+          ))}
+           <div className="column is-3">
             <CharacterPreview character={testCharacter as Character} />
           </div>
           <div className="column is-3">
@@ -32,7 +51,7 @@ export function SavedCharactersPage() {
           <div className="column is-3">
             <CharacterPreview character={testCharacter as Character} />
           </div>
-        </div>
+      </div>
 
         <hr />
         <Link to="/" className="button">

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,13 +1,14 @@
 import Dexie, { Table } from "dexie";
 import { Character } from "../interfaces/character";
+import { useState } from "react"
 
-interface Props {
+export interface DBProps {
     character: Character;
 }
 
 export class DexieDatabase extends Dexie {
 
-    characters!: Table<Props>
+    characters!: Table<DBProps>
 
     constructor() {
         super("characterDatabase");
@@ -19,16 +20,35 @@ export class DexieDatabase extends Dexie {
 
 export const db = new DexieDatabase();
 
-export function AddCharacterForm(props: Props) {
+export function AddCharacterForm(props: DBProps) {
     if (!db.isOpen()) db.open();
     async function addCharacter() {
         try {
-            const id = await db.characters.add(props);
-            console.log(id);
+            await db.characters.add(props);
         } catch (error) {
             console.log(error);
         }
     }
 
     addCharacter();
+}
+
+export async function GetAllCharacters() {
+    
+    let characters: Character[] = [];
+
+    // Gets all entries from the database and then makes sure it is a valid character
+    // Error checking is done here instead of on-site
+    async function getCharacters() {
+        let dbprops = await db.characters.toArray(); 
+        for (let i = 0; i < dbprops.length; i++) {
+            if (dbprops[i].character as Character == undefined) continue;
+            characters.push(dbprops[i].character);
+        }
+    }
+
+    await getCharacters();
+
+    console.log(characters);
+    return characters;
 }


### PR DESCRIPTION
This commit makes custom characters (that were stored locally via Dexie) visible on the SavedCharacters page. All error checking is done in the database request.

![image](https://user-images.githubusercontent.com/20057606/161853148-b5be5c09-f1b4-48a0-8669-7dced36e1b95.png)


A nice cleanup thing would be to add content placeholders while the characters are being retrieved.

As an additional note, the dev view of IndexedDB (through the browser) may show character info weirdly. This is because there is too much data and it gets truncated at a weird spot (at least from what I can tell.) It will still be processed normally.